### PR TITLE
Update rubyzip dependency

### DIFF
--- a/extensionator.gemspec
+++ b/extensionator.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.1"
-  spec.add_runtime_dependency "rubyzip", "1.2.0"
+  spec.add_runtime_dependency "rubyzip", "1.2.1"
   spec.add_runtime_dependency "slop", "~> 4.4"
   spec.authors = ["Isaac Cambron"]
   spec.description = "A tool for packaging Chrome extensions"


### PR DESCRIPTION
rubyzip v1.2.1 fixes a security vulnerability: rubyzip/rubyzip#315

See https://github.com/rubyzip/rubyzip/releases/tag/v1.2.1 for additional changes.