### PR TITLE
Update rubyzip dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    extensionator (2.1.3)
-      rubyzip (= 1.2.1)
+    extensionator (2.1.4)
+      rubyzip (= 1.2.2)
       slop (~> 4.4)
 
 GEM
@@ -10,8 +10,8 @@ GEM
   specs:
     minitest (5.11.3)
     rake (12.3.0)
-    rubyzip (1.2.1)
-    slop (4.6.1)
+    rubyzip (1.2.2)
+    slop (4.6.2)
 
 PLATFORMS
   ruby

--- a/extensionator.gemspec
+++ b/extensionator.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.1"
-  spec.add_runtime_dependency "rubyzip", "1.2.1"
+  spec.add_runtime_dependency "rubyzip", "1.2.2"
   spec.add_runtime_dependency "slop", "~> 4.4"
   spec.authors = ["Isaac Cambron"]
   spec.description = "A tool for packaging Chrome extensions"


### PR DESCRIPTION
rubyzip 1.2.2 includes the fix for [CVE-2018-1000544](https://nvd.nist.gov/vuln/detail/CVE-2018-1000544): https://github.com/rubyzip/rubyzip/issues/369

Unfortunately there is no changelog for 1.2.2, https://github.com/rubyzip/rubyzip/compare/v1.2.1...v1.2.2