### PR TITLE
Update rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
+  - 2.7
 before_install:
   - gem update --system # Need for Ruby 2.5.0. https://github.com/travis-ci/travis-ci/issues/8978
 script: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
   - 2.7

--- a/extensionator.gemspec
+++ b/extensionator.gemspec
@@ -2,7 +2,7 @@ lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.add_development_dependency "bundler", "~> 1.1"
+  spec.add_development_dependency "bundler", ">= 1.1", "< 3"
   spec.add_development_dependency "minitest", "~> 5.11"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_runtime_dependency "rubyzip", "1.2.2"


### PR DESCRIPTION
extensionator seems working on Ruby 2.6 and 2.7.
This PR expresses supporting them .